### PR TITLE
Making Event extra as generic pointer

### DIFF
--- a/Event.h
+++ b/Event.h
@@ -19,9 +19,9 @@ struct Event
 {
   Event() : label(NULL) {}
   Event(const char *cLabel) : label(cLabel) {}
-  Event(const char *cLabel, const char *cExtra) : label(cLabel), extra(cExtra) {}
+  Event(const char *cLabel, const void *cExtra) : label(cLabel), extra(cExtra) {}
   const char *extra;
-  const char *label;
+  const void *label;
 };
 
 /**


### PR DESCRIPTION
Making Event extra as generic pointer will help to pass any type of argument.
